### PR TITLE
Configured logging to text file for BucStop using Serilog

### DIFF
--- a/Bucstop WebApp/BucStop/BucStop.csproj
+++ b/Bucstop WebApp/BucStop/BucStop.csproj
@@ -10,6 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.4" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bucstop WebApp/BucStop/Program.cs
+++ b/Bucstop WebApp/BucStop/Program.cs
@@ -1,10 +1,19 @@
 using BucStop;
+using Serilog;
 
 /*
  * This is the base program which starts the project.
  */
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Sets up Serilog for logging to console and log file
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .WriteTo.File("Logs/logs.log", rollingInterval: RollingInterval.Day, retainedFileCountLimit: 7) // Creates a new log file each day and keeps up to 7 log files (7 days)
+    .CreateLogger();
+
+builder.Host.UseSerilog();
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
@@ -23,15 +32,6 @@ builder.Services.AddAuthentication("CustomAuthenticationScheme").AddCookie("Cust
 {
     options.LoginPath = "/Account/Login";
 });
-
-// This creates the timestamp for the logger.
-builder.Logging.AddSimpleConsole(options =>
-{
-    options.IncludeScopes = true;
-    options.TimestampFormat = "yyyy-MM-dd HH:mm:ss ";
-});
-
-
 
 builder.Services.AddSingleton<GameService>();
 


### PR DESCRIPTION
This adds the Serilog packages to the bucstop.csproj file, and configures Serilog in BucStop's program.cs. Serilog logs to both the console and a log file, which is stored in "Logs/logs.log". It is configured to keep only 7 log files (7 days) so the log files don't take up too much storage. To add custom logs, you simply use ILogger that is already implemented in Bucstop. Log files were already included in the gitignore file, so they won't be added to GitHub (Kinser also recommended this).