### PR TITLE
Bug Fix - remove termination after cleanup

### DIFF
--- a/Scripts/deploy.sh
+++ b/Scripts/deploy.sh
@@ -96,7 +96,6 @@ cleanup() {
         done
     fi
 
-    exit 1
 }
 
 # Bind cleanup to Ctrl+C and termination signals


### PR DESCRIPTION
The script was terminating after resource cleanup which happens both prior to the builds and on interupts. I removed that so the script would run properly. 