### PR TITLE
Sprint6 Email Verification Case Sensitivity Bug fixes

### DIFF
--- a/Bucstop WebApp/BucStop/Controllers/AccountController.cs
+++ b/Bucstop WebApp/BucStop/Controllers/AccountController.cs
@@ -30,7 +30,8 @@ namespace BucStop.Controllers
             Stopwatch stopwatch = new Stopwatch();
             stopwatch.Start();
 
-            if (Regex.IsMatch(email, @"\b[A-Za-z0-9._%+-]+@etsu\.edu\b"))
+            //ToLower added to remove case sensitivity. Current Font makes all lettering look like capital letters.
+            if (Regex.IsMatch(email.ToLower(), @"\b[A-Za-z0-9._%+-]+@etsu\.edu\b"))
             {
                 // If authentication is successful, create a ClaimsPrincipal and sign in the user
                 var claims = new[]

--- a/Team-3-BucStop_APIGateway/APIGateway/Controllers/GatewayController.cs
+++ b/Team-3-BucStop_APIGateway/APIGateway/Controllers/GatewayController.cs
@@ -80,11 +80,11 @@ namespace Gateway
                 if (response.IsSuccessStatusCode)
                 {
                     // Deserialize the response content to a GameInfo object
-                    var gameinfo = await response.Content.ReadFromJsonAsync<List<GameInfo>>();
+                    var gameInfo = await response.Content.ReadFromJsonAsync<List<GameInfo>>();
                     //Add object to list
                     lock (TheInfo)
                     {
-                        TheInfo.AddRange(gameinfo);
+                        TheInfo.AddRange(gameInfo);
                     }
                 }
                 else


### PR DESCRIPTION
Added ToLower method use on email to remove case sensitivity because that shouldn't matter for an email and our website font displays as all Capitals which can be confusing.
Adjust one variable and code comment to match code standards.