### PR TITLE
Update get game info calls.

### DIFF
--- a/Bucstop WebApp/BucStop/Controllers/GamesController.cs
+++ b/Bucstop WebApp/BucStop/Controllers/GamesController.cs
@@ -101,7 +101,8 @@ namespace BucStop.Controllers
         public async Task<List<Game>> GetGamesWithInfo()
         {
 
-            List<Game> games = _gameService.GetGames();
+            List<Game> games = new List<Game>();
+
             try
             {
                 GameInfo[] gameInfos = await _httpClient.GetGamesAsync();
@@ -115,17 +116,24 @@ namespace BucStop.Controllers
                     _logger.LogWarning("API returned 0 games.");
                 }
 
-                foreach (Game game in games)
+                foreach (GameInfo info in gameInfos)
                 {
-                    GameInfo info = gameInfos.FirstOrDefault(x => x.Title == game.Title);
+                    Game game = new Game();
+
                     if (info != null)
                     {
+                        game.Id = info.Id;
+                        game.Title = info.Title;
+                        game.Content = info.Content;
+                        game.Thumbnail = info.Thumbnail;
                         game.Author = info.Author;
                         game.HowTo = info.HowTo;
                         game.DateAdded = info.DateAdded;
                         game.Description = $"{info.Description} \n {info.DateAdded}";
                         game.LeaderBoard = info.LeaderBoard;
                     }
+
+                    games.Add(game);
                 }
             }
             catch (Exception ex)

--- a/Bucstop WebApp/BucStop/MicroServices/GameInfo.cs
+++ b/Bucstop WebApp/BucStop/MicroServices/GameInfo.cs
@@ -2,11 +2,14 @@
 {
     public class GameInfo
     {
-        public string Title {  get; set; }
+        public int Id { get; set; }
+        public string Title { get; set; }
         public string Author { get; set; }
+        public string Content { get; set; }
         public string Description { get; set; }
         public string DateAdded { get; set; }
         public string HowTo { get; set; }
+        public string Thumbnail { get; set; }
         public Stack<KeyValuePair<string, int>> LeaderBoard { get; set; }
     }
 }


### PR DESCRIPTION
Modified GameInfo Objects to be the same in the WebApp as in the Tetris Microservice (outside an additional item in WebApp version). In addition, updated the GetGameInfo request to no longer use games.json and instead use the GameInfo objects pulled from the Microservices. games.json is still needed for some other purposes and code that references it should probably also be updated at a later date. Might have introduced a very small bug where refreshing the games page on the webpage can swap the places of each game, but this does not detract from functionality.