### PR TITLE
Sprint7 - Microservices Dynamic URLs for Dev and Prod

### DIFF
--- a/Team-3-BucStop_Pong/Pong/Controllers/PongController.cs
+++ b/Team-3-BucStop_Pong/Pong/Controllers/PongController.cs
@@ -14,13 +14,25 @@ namespace Pong
     [Route("[controller]")]
     public class PongController : ControllerBase
     {
+        private readonly ILogger<PongController> _logger;
+        private readonly IConfiguration _config;
+        private static string gameURL;
+
+        public PongController(ILogger<PongController> logger, IConfiguration config)
+        {
+            _logger = logger;
+            _config = config;
+            gameURL = _config["MicroserviceUrls:Pong"];
+        }
+
         private static readonly List<GameInfo> TheInfo = new List<GameInfo>
         {
             new GameInfo { 
                 Id = 3,
                 Title = "Pong",
                 //Content = "~/js/pong.js",
-                Content = "https://localhost:1941/js/pong.js",
+                //Content = "https://localhost:1941/js/pong.js",
+                Content = gameURL,
                 Author = "Fall 2023 Semester",
                 DateAdded = "",
                 Description = "Pong is a classic arcade game where the player uses a paddle to hit a ball against a computer's paddle. Either party scores when the ball makes it past the opponent's paddle.",
@@ -30,16 +42,14 @@ namespace Pong
 
         };
 
-        private readonly ILogger<PongController> _logger;
-
-        public PongController(ILogger<PongController> logger)
-        {
-            _logger = logger;
-        }
-
         [HttpGet]
         public IEnumerable<GameInfo> Get()
         {
+            // Confirm the Content URL is assigned if it was not available when initialized
+            if (TheInfo[0].Content == null)
+            {
+                TheInfo[0].Content = gameURL;
+            }
             return TheInfo;
         }
     }

--- a/Team-3-BucStop_Pong/Pong/Pong.csproj
+++ b/Team-3-BucStop_Pong/Pong/Pong.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,6 +11,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.Production.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/Team-3-BucStop_Pong/Pong/appsettings.Development.json
+++ b/Team-3-BucStop_Pong/Pong/appsettings.Development.json
@@ -1,8 +1,12 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "MicroserviceUrls": {
+        "Pong": "https://localhost:1941/js/pong.js"
     }
-  }
 }

--- a/Team-3-BucStop_Pong/Pong/appsettings.Production.json
+++ b/Team-3-BucStop_Pong/Pong/appsettings.Production.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Tetris": "https://localhost:2626/js/tetris.js"
+        "Pong": "http://3.232.16.65:1941/js/pong.js"
     }
 }

--- a/Team-3-BucStop_Snake/Snake/Controllers/SnakeController.cs
+++ b/Team-3-BucStop_Snake/Snake/Controllers/SnakeController.cs
@@ -14,13 +14,27 @@ namespace Snake
     [Route("[controller]")]
     public class SnakeController : ControllerBase
     {
+        private readonly ILogger<SnakeController> _logger;
+        private readonly IConfiguration _config;
+        private static string gameURL;
+
+
+        public SnakeController(ILogger<SnakeController> logger, IConfiguration config)
+        {
+            _logger = logger;
+            _config = config;
+            gameURL = _config["MicroserviceUrls:Snake"];
+        }
+
+
         private static readonly List<GameInfo> TheInfo = new List<GameInfo>
         {
-            new GameInfo { 
+            new GameInfo {
                 Id = 1,
                 Title = "Snake",
                 //Content = "~/js/snake.js",
-                Content = "https://localhost:1948/js/snake.js",
+                //Content = "https://localhost:1948/js/snake.js",
+                Content = gameURL, // id 1
                 Author = "Fall 2023 Semester",
                 DateAdded = "",
                 Description = "Snake is a classic arcade game that challenges the player to control a snake-like creature that grows longer as it eats apples. The player must avoid hitting the walls or the snake's own body, which can end the game.\r\n",
@@ -30,16 +44,14 @@ namespace Snake
 
         };
 
-        private readonly ILogger<SnakeController> _logger;
-
-        public SnakeController(ILogger<SnakeController> logger)
-        {
-            _logger = logger;
-        }
-
         [HttpGet]
         public IEnumerable<GameInfo> Get()
         {
+            // Confirm the Content URL is assigned if it was not available when initialized
+            if (TheInfo[0].Content == null)
+            {
+                TheInfo[0].Content = gameURL;
+            }
             return TheInfo;
         }
     }

--- a/Team-3-BucStop_Snake/Snake/Snake.csproj
+++ b/Team-3-BucStop_Snake/Snake/Snake.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,6 +11,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.Production.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/Team-3-BucStop_Snake/Snake/appsettings.Development.json
+++ b/Team-3-BucStop_Snake/Snake/appsettings.Development.json
@@ -1,8 +1,12 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "MicroserviceUrls": {
+        "Snake": "https://localhost:1948/js/snake.js"
     }
-  }
 }

--- a/Team-3-BucStop_Snake/Snake/appsettings.Production.json
+++ b/Team-3-BucStop_Snake/Snake/appsettings.Production.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Tetris": "https://localhost:2626/js/tetris.js"
+        "Snake": "http://3.232.16.65:1948/js/snake.js"
     }
 }

--- a/Team-3-BucStop_Tetris/Tetris/Controllers/TetrisController.cs
+++ b/Team-3-BucStop_Tetris/Tetris/Controllers/TetrisController.cs
@@ -15,6 +15,17 @@ namespace Tetris
     [Route("[controller]")]
     public class TetrisController : ControllerBase
     {
+        private readonly ILogger<TetrisController> _logger;
+        private readonly IConfiguration _config;
+        private static string gameURL;
+
+        public TetrisController(ILogger<TetrisController> logger, IConfiguration config)
+        {
+            _logger = logger;
+            _config = config;
+            gameURL = _config["MicroserviceUrls:Tetris"];
+        }
+
         private static readonly List<GameInfo> TheInfo = new List<GameInfo>
         {
             new GameInfo {
@@ -23,9 +34,8 @@ namespace Tetris
                 Title = "Tetris",
                 Author = "Fall 2023 Semester",
                 //Content = "~/js/tetris.js", //changing URL now that the MS hosts game code
-                // need to probably change this url so that it is aware of the environment dynamically?
-                // i think this would mean using one of the app settings variables instead of hard coding
-                Content = "https://localhost:2626/js/tetris.js",
+                //Content = "https://localhost:2626/js/tetris.js",
+                Content = gameURL,
                 DateAdded = "",
                 Description = "Tetris is a classic arcade puzzle game where the player has to arrange falling blocks, also known as Tetronimos, of different shapes and colors to form complete rows on the bottom of the screen. The game gets faster and harder as the player progresses, and ends when the Tetronimos reach the top of the screen.",
                 HowTo = "Control with arrow keys: Up arrow to spin, down to speed up fall, space to insta-drop.",
@@ -33,16 +43,15 @@ namespace Tetris
             }
         };
 
-        private readonly ILogger<TetrisController> _logger;
-
-        public TetrisController(ILogger<TetrisController> logger)
-        {
-            _logger = logger;
-        }
 
         [HttpGet]
         public IEnumerable<GameInfo> Get()
         {
+            // Confirm the Content URL is assigned if it was not available when initialized
+            if (TheInfo[0].Content == null)
+            {
+                TheInfo[0].Content = gameURL;
+            }
             return TheInfo;
         }
     }

--- a/Team-3-BucStop_Tetris/Tetris/Tetris.csproj
+++ b/Team-3-BucStop_Tetris/Tetris/Tetris.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -11,6 +11,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.Production.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/Team-3-BucStop_Tetris/Tetris/appsettings.Production.json
+++ b/Team-3-BucStop_Tetris/Tetris/appsettings.Production.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Tetris": "https://localhost:2626/js/tetris.js"
+        "Tetris": "http://3.232.16.65:2626/js/tetris.js"
     }
 }


### PR DESCRIPTION
Update each Microservice so that the content URL changes between Dev and Prod via appsettings injection. Will need to test on AWS as well.

**Still needs to be tested in Prod EC2 Environment to see if URLs work there.**