### PR TITLE
Sprint 8 - Add Docker Support and Environment aware configuration for services (EC2 and local)

### DIFF
--- a/Bucstop WebApp/BucStop/Controllers/GamesController.cs
+++ b/Bucstop WebApp/BucStop/Controllers/GamesController.cs
@@ -1,4 +1,4 @@
-﻿using BucStop.Models;
+﻿﻿using BucStop.Models;
 using BucStop.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -135,6 +135,9 @@ namespace BucStop.Controllers
                         game.DateAdded = info.DateAdded;
                         game.Description = $"{info.Description} \n {info.DateAdded}";
                         game.LeaderBoard = info.LeaderBoard;
+
+                        _logger.LogInformation("Game ID {Id} Content URL: {Content}", info.Id, info.Content);
+
                     }
 
                     games.Add(game);
@@ -144,6 +147,7 @@ namespace BucStop.Controllers
             {
                 _logger.LogError(ex, "Error retrieving game information from API.");
             }
+
 
             return games;
         }

--- a/Bucstop WebApp/BucStop/Program.cs
+++ b/Bucstop WebApp/BucStop/Program.cs
@@ -38,15 +38,15 @@ builder.Host.UseSerilog();
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 
-var provider=builder.Services.BuildServiceProvider();
-var configuration=provider.GetRequiredService<IConfiguration>();
+// var provider=builder.Services.BuildServiceProvider();
+// var configuration=provider.GetRequiredService<IConfiguration>();
 
 builder.Services.AddHttpClient<MicroClient>(client =>
 {
-    var baseAddress = new Uri(configuration.GetValue<string>("Gateway"));
-
+    var baseAddress = new Uri(builder.Configuration.GetValue<string>("Gateway"));
     client.BaseAddress = baseAddress;
 });
+
 
 builder.Services.AddAuthentication("CustomAuthenticationScheme").AddCookie("CustomAuthenticationScheme", options =>
 {
@@ -58,6 +58,17 @@ builder.Services.AddHostedService<ApiHeartbeatService>();
 
 var app = builder.Build();
 
+var config = app.Configuration;
+
+var environment = app.Environment.EnvironmentName;
+var gateway = config.GetValue<string>("Gateway");
+var micro = config.GetValue<string>("Micro");
+
+foreach (var kvp in config.AsEnumerable())
+{
+    Log.Debug("{Key} = {Value}", kvp.Key, kvp.Value);
+}
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
@@ -66,7 +77,7 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
-app.UseHttpsRedirection();
+// app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();

--- a/Bucstop WebApp/BucStop/Program.cs
+++ b/Bucstop WebApp/BucStop/Program.cs
@@ -61,8 +61,8 @@ var app = builder.Build();
 var config = app.Configuration;
 
 var environment = app.Environment.EnvironmentName;
-var gateway = config.GetValue<string>("Gateway");
-var micro = config.GetValue<string>("Micro");
+var gateway = config["Gateway"];
+var micro = config["Micro"];
 
 foreach (var kvp in config.AsEnumerable())
 {

--- a/Bucstop WebApp/BucStop/Services/ApiHeartbeatService.cs
+++ b/Bucstop WebApp/BucStop/Services/ApiHeartbeatService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration; // added this
 using System;
 using System.Net.Http;
 using System.Threading;
@@ -11,12 +12,17 @@ namespace BucStop.Services
     {
         private readonly HttpClient _httpClient;
         private readonly ILogger<ApiHeartbeatService> _logger;
-        private readonly string _healthCheckUrl = "https://localhost:4141/health"; // API Gateway health endpoint
+        private readonly string _healthCheckUrl;
 
-        public ApiHeartbeatService(HttpClient httpClient, ILogger<ApiHeartbeatService> logger)
+        public ApiHeartbeatService(
+            HttpClient httpClient,
+            ILogger<ApiHeartbeatService> logger,
+            IConfiguration configuration) // inject config here
         {
             _httpClient = httpClient;
             _logger = logger;
+            var gateway = configuration.GetValue<string>("Gateway");
+            _healthCheckUrl = $"{gateway}/health";
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/Bucstop WebApp/BucStop/Services/ApiHeartbeatService.cs
+++ b/Bucstop WebApp/BucStop/Services/ApiHeartbeatService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using BucStop.Models;
 
 namespace BucStop.Services
 {
@@ -12,16 +13,15 @@ namespace BucStop.Services
     {
         private readonly HttpClient _httpClient;
         private readonly ILogger<ApiHeartbeatService> _logger;
+        private readonly IConfiguration _config;
         private readonly string _healthCheckUrl;
 
-        public ApiHeartbeatService(
-            HttpClient httpClient,
-            ILogger<ApiHeartbeatService> logger,
-            IConfiguration configuration) // inject config here
+        public ApiHeartbeatService(HttpClient httpClient, ILogger<ApiHeartbeatService> logger, IConfiguration config)
         {
             _httpClient = httpClient;
             _logger = logger;
-            var gateway = configuration.GetValue<string>("Gateway");
+            _config = config;
+            var gateway = _config["Gateway"];
             _healthCheckUrl = $"{gateway}/health";
         }
 

--- a/Bucstop WebApp/BucStop/appsettings.containers.json
+++ b/Bucstop WebApp/BucStop/appsettings.containers.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Micro": "http://bucstop",
+  "Gateway": "http://api-gateway"
+}

--- a/Bucstop WebApp/BucStop/appsettings.containersLocal.json
+++ b/Bucstop WebApp/BucStop/appsettings.containersLocal.json
@@ -1,0 +1,11 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Micro": "http://bucstop",
+  "Gateway": "http://api-gateway"
+}

--- a/Scripts/deploy.sh
+++ b/Scripts/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export ASPNETCORE_ENVIRONMENT=Production
+export env=containers
 # ─────────────────────────────────────────────────────────────
 #  Config / Constants
 # ─────────────────────────────────────────────────────────────

--- a/Team-3-BucStop_APIGateway/APIGateway/APIGateway.csproj
+++ b/Team-3-BucStop_APIGateway/APIGateway/APIGateway.csproj
@@ -14,4 +14,12 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="appsettings.containersLocal.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/Team-3-BucStop_APIGateway/APIGateway/Controllers/GatewayController.cs
+++ b/Team-3-BucStop_APIGateway/APIGateway/Controllers/GatewayController.cs
@@ -5,121 +5,98 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Json;
-using System.Text;
+using Gateway;
 
 namespace Gateway
 {
-    /// <summary>
-    /// Controller responsible for handling requests and responses at the gateway.
-    /// </summary>
     [ApiController]
     [Route("[controller]")]
     public class GatewayController : ControllerBase
     {
-        private readonly HttpClient _httpClient; // Making readonly ensures thread safety 
-        private readonly ILogger<GatewayController> _logger; // Making readonly ensures thread safety 
-        private readonly List<GameInfo> TheInfo;
+        private readonly ILogger<GatewayController> _logger;
         private readonly IConfiguration _config;
+        private readonly List<GameInfo> _gameInfos;
 
-        public GatewayController(HttpClient httpClient, ILogger<GatewayController> logger, IConfiguration config)
+        public GatewayController(ILogger<GatewayController> logger, IConfiguration config)
         {
-            _httpClient = httpClient;
             _logger = logger;
             _config = config;
-            TheInfo = new List<GameInfo>();
+            _gameInfos = new List<GameInfo>();
         }
 
-        /// <summary>
-        /// Handles GET requests to retrieve game information from microservices.
-        /// </summary>
-        /// <returns>A collection of GameInfo objects.</returns>
         [HttpGet]
         public async Task<IEnumerable<GameInfo>> Get()
         {
             try
             {
-                var SnakeUrl = _config["MicroserviceUrls:Snake"]; // id 1
-                var TetrisUrl = _config["MicroserviceUrls:Tetris"]; // id 2
-                var PongUrl = _config["MicroserviceUrls:Pong"]; // id 3
+                var gameKeys = new[] { "Snake", "Tetris", "Pong" };
 
-                var SnakeTask = AddGameInfo(SnakeUrl, "/Snake"); //id 1
-                var TetrisTask = AddGameInfo(TetrisUrl, "/Tetris"); //id 2
-                var PongTask = AddGameInfo(PongUrl, "/Pong"); //id 3
-                await Task.WhenAll(SnakeTask, TetrisTask, PongTask);
-                return TheInfo;
+                var fetchTasks = new List<Task>();
+                foreach (var game in gameKeys)
+                {
+                    var internalUrl = _config[$"Microservices:{game}"];
+                    var publicUrl = _config[$"PublicUrls:{game}"];
+                    var jsPath = $"/js/{game.ToLowerInvariant()}.js";
+
+                    fetchTasks.Add(FetchGameInfo(internalUrl, $"/{game}", publicUrl + jsPath));
+                }
+
+                await Task.WhenAll(fetchTasks);
+                return _gameInfos;
             }
             catch (Exception ex)
             {
-                _logger.LogError($"An error occurred while fetching data from microservice: {ex.Message}");
-                // Return a placeholder list of GameInfo objects indicating failure
+                _logger.LogError(ex, "Error occurred while gathering game info");
                 return GenerateFailureResponse();
             }
         }
 
-         /// <summary>
-         /// Attempts to retrieve gameinfo object from a microservice that holds a game info object (snake, tetris, pong)
-         /// and adds the game info into a list of game info objects
-         /// </summary>
-         /// <param name="gameinfolist"></param>
-         /// <param name="baseUrl"></param>
-         /// <param name="endpoint"></param>
-         /// <returns></returns>
-         [ApiExplorerSettings(IgnoreApi = true)]
-        public async Task AddGameInfo(string baseUrl, string endpoint)
+        [ApiExplorerSettings(IgnoreApi = true)]
+        private async Task FetchGameInfo(string internalUrl, string endpoint, string publicJsUrl)
         {
             try
             {
-                using var client = new HttpClient();
-                //Set the base address of the microservice 
-                client.BaseAddress = new Uri(baseUrl);
+                using var client = new HttpClient { BaseAddress = new Uri(internalUrl) };
+                var response = await client.GetAsync(endpoint);
 
-                //Read the data from the endpoint 
-                HttpResponseMessage response = await client.GetAsync(endpoint);
-
-                // Check if the request was successful
                 if (response.IsSuccessStatusCode)
                 {
-                    // Deserialize the response content to a GameInfo object
-                    var gameInfo = await response.Content.ReadFromJsonAsync<List<GameInfo>>();
-                    //Add object to list
-                    lock (TheInfo)
+                    var gameInfoList = await response.Content.ReadFromJsonAsync<List<GameInfo>>();
+                    if (gameInfoList != null)
                     {
-                        TheInfo.AddRange(gameInfo);
+                        foreach (var game in gameInfoList)
+                        {
+                            game.Content = publicJsUrl;
+                        }
+
+                        lock (_gameInfos)
+                        {
+                            _gameInfos.AddRange(gameInfoList);
+                        }
                     }
                 }
                 else
                 {
-                    _logger.LogError($"Failed to retrieve data from microservice at endpoint {endpoint}. Status code: {response.StatusCode}");
+                    _logger.LogError("Failed to get game info from {Url}{Endpoint} - Status: {Status}", internalUrl, endpoint, response.StatusCode);
                 }
-
             }
-            catch (Exception ex) //Log error and return false if any exception occurs
-            { 
-                _logger.LogError(ex.Message);
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception in FetchGameInfo for {Url}{Endpoint}", internalUrl, endpoint);
             }
         }
 
-        /// <summary>
-        /// Generates a placeholder list of GameInfo objects indicating failure to retrieve data.
-        /// Written with ChatGPT
-        /// </summary>
-        /// <returns>A collection of GameInfo objects indicating failure.</returns>
         private IEnumerable<GameInfo> GenerateFailureResponse()
         {
-            // Using IEnumerable allows flexibility in returning a placeholder response.
-            // It allows the method to return different types of collections (e.g., List, Array) if needed in the future.
-            // In this case, IEnumerable provides a simple way to return a list of failed responses.
-
-            // Generate a placeholder list of GameInfo objects indicating failure to retrieve data
             return new List<GameInfo>
             {
                 new GameInfo
                 {
-                    Title = "Failed to retrieve from Microservice",
-                    Author = "Failed to retrieve from Microservice",
-                    Description = "Failed to retrieve from Microservice",
-                    HowTo = "Failed to retrieve from Microservice",
-                    LeaderBoardStack = new Stack<KeyValuePair<string, int>>() // Initializing an empty stack
+                    Title = "Unavailable",
+                    Author = "Unavailable",
+                    Description = "Failed to retrieve data",
+                    HowTo = "N/A",
+                    LeaderBoardStack = new Stack<KeyValuePair<string, int>>()
                 }
             };
         }

--- a/Team-3-BucStop_APIGateway/APIGateway/Controllers/GatewayController.cs
+++ b/Team-3-BucStop_APIGateway/APIGateway/Controllers/GatewayController.cs
@@ -16,11 +16,13 @@ namespace Gateway
         private readonly ILogger<GatewayController> _logger;
         private readonly IConfiguration _config;
         private readonly List<GameInfo> _gameInfos;
+        private readonly IHostEnvironment _host;
 
-        public GatewayController(ILogger<GatewayController> logger, IConfiguration config)
+        public GatewayController(ILogger<GatewayController> logger, IConfiguration config, IHostEnvironment host)
         {
             _logger = logger;
             _config = config;
+            _host = host;
             _gameInfos = new List<GameInfo>();
         }
 
@@ -34,7 +36,19 @@ namespace Gateway
                 var fetchTasks = new List<Task>();
                 foreach (var game in gameKeys)
                 {
-                    var internalUrl = _config[$"Microservices:{game}"];
+                    string internalUrl;
+
+                    if (_host.IsDevelopment())
+                    {
+                        internalUrl = _config[$"PublicUrls:{game}"];
+                        _logger.LogInformation($"Using Development URL for {game}: {internalUrl}");
+                    }
+                    else
+                    {
+                        internalUrl = _config[$"Microservices:{game}"];
+                        _logger.LogInformation($"Using Container URL for {game}: {internalUrl}");
+                    }
+
                     var publicUrl = _config[$"PublicUrls:{game}"];
                     var jsPath = $"/js/{game.ToLowerInvariant()}.js";
 

--- a/Team-3-BucStop_APIGateway/APIGateway/appsettings.Development.json
+++ b/Team-3-BucStop_APIGateway/APIGateway/appsettings.Development.json
@@ -1,15 +1,16 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
-  "AllowedHosts": "*",
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "AllowedHosts": "*",
 
-  "MicroserviceUrls": {
-    "Snake": "https://localhost:1948",
-    "Pong": "https://localhost:1941",
-    "Tetris": "https://localhost:2626"
-  }
+    "PublicUrls": {
+        "Snake": "https://localhost:1948",
+        "Pong": "https://localhost:1941",
+        "Tetris": "https://localhost:2626",
+        "Gateway": "https://localhost:4141"
+    }
 }

--- a/Team-3-BucStop_APIGateway/APIGateway/appsettings.containers.json
+++ b/Team-3-BucStop_APIGateway/APIGateway/appsettings.containers.json
@@ -1,0 +1,20 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "PublicUrls": {
+  "Snake": "http://localhost:8082",
+  "Pong": "http://localhost:8083",
+  "Tetris": "http://localhost:8084",
+  "Gateway": "http://localhost:8081"
+},
+"Microservices": {
+  "Snake": "http://game-snake",
+  "Pong": "http://game-pong",
+  "Tetris": "http://game-tetris",
+  "Gateway": "http://api-gateway"
+}
+}

--- a/Team-3-BucStop_APIGateway/APIGateway/appsettings.containers.json
+++ b/Team-3-BucStop_APIGateway/APIGateway/appsettings.containers.json
@@ -5,12 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "PublicUrls": {
-  "Snake": "http://localhost:8082",
-  "Pong": "http://localhost:8083",
-  "Tetris": "http://localhost:8084",
-  "Gateway": "http://localhost:8081"
-},
+    "PublicUrls": {
+        "Snake": "http://3.232.16.65:8082",
+        "Pong": "http://3.232.16.65:8083",
+        "Tetris": "http://3.232.16.65:8084",
+        "Gateway": "http://3.232.16.65:8081"
+    },
 "Microservices": {
   "Snake": "http://game-snake",
   "Pong": "http://game-pong",

--- a/Team-3-BucStop_APIGateway/APIGateway/appsettings.containersLocal.json
+++ b/Team-3-BucStop_APIGateway/APIGateway/appsettings.containersLocal.json
@@ -1,0 +1,20 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+    "PublicUrls": {
+        "Snake": "http://localhost:8082",
+        "Pong": "http://localhost:8083",
+        "Tetris": "http://localhost:8084",
+        "Gateway": "http://localhost:8081"
+    },
+"Microservices": {
+  "Snake": "http://game-snake",
+  "Pong": "http://game-pong",
+  "Tetris": "http://game-tetris",
+  "Gateway": "http://api-gateway"
+}
+}

--- a/Team-3-BucStop_Pong/Pong/Pong.csproj
+++ b/Team-3-BucStop_Pong/Pong/Pong.csproj
@@ -14,6 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="appsettings.containersLocal.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
     <Content Update="appsettings.Production.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/Team-3-BucStop_Pong/Pong/appsettings.Production.json
+++ b/Team-3-BucStop_Pong/Pong/appsettings.Production.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Pong": "http://3.232.16.65:1941/js/pong.js"
+        "Pong": "http://3.232.16.65:8083/js/pong.js"
     }
 }

--- a/Team-3-BucStop_Pong/Pong/appsettings.containers.json
+++ b/Team-3-BucStop_Pong/Pong/appsettings.containers.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Pong": "http://localhost:8083/js/pong.js"
+        "Pong": "http://3.232.16.65:8083/js/pong.js"
     }
 }

--- a/Team-3-BucStop_Pong/Pong/appsettings.containers.json
+++ b/Team-3-BucStop_Pong/Pong/appsettings.containers.json
@@ -1,0 +1,12 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "MicroserviceUrls": {
+        "Pong": "http://localhost:8083/js/pong.js"
+    }
+}

--- a/Team-3-BucStop_Pong/Pong/appsettings.containersLocal.json
+++ b/Team-3-BucStop_Pong/Pong/appsettings.containersLocal.json
@@ -1,0 +1,12 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "MicroserviceUrls": {
+        "Pong": "http://localhost:8083/js/pong.js"
+    }
+}

--- a/Team-3-BucStop_Snake/Snake/appsettings.Production.json
+++ b/Team-3-BucStop_Snake/Snake/appsettings.Production.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Snake": "http://3.232.16.65:1948/js/snake.js"
+        "Snake": "http://3.232.16.65:8082/js/snake.js"
     }
 }

--- a/Team-3-BucStop_Snake/Snake/appsettings.containers.json
+++ b/Team-3-BucStop_Snake/Snake/appsettings.containers.json
@@ -1,0 +1,12 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "MicroserviceUrls": {
+        "Snake": "http://localhost:8082/js/snake.js"
+    }
+}

--- a/Team-3-BucStop_Snake/Snake/appsettings.containers.json
+++ b/Team-3-BucStop_Snake/Snake/appsettings.containers.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Snake": "http://localhost:8082/js/snake.js"
+        "Snake": "http://3.232.16.65:8082/js/snake.js"
     }
 }

--- a/Team-3-BucStop_Snake/Snake/appsettings.containersLocal.json
+++ b/Team-3-BucStop_Snake/Snake/appsettings.containersLocal.json
@@ -1,0 +1,12 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "MicroserviceUrls": {
+        "Snake": "http://localhost:8082/js/snake.js"
+    }
+}

--- a/Team-3-BucStop_Tetris/Tetris/Tetris.csproj
+++ b/Team-3-BucStop_Tetris/Tetris/Tetris.csproj
@@ -14,6 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="appsettings.containersLocal.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
     <Content Update="appsettings.Production.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/Team-3-BucStop_Tetris/Tetris/appsettings.Production.json
+++ b/Team-3-BucStop_Tetris/Tetris/appsettings.Production.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Tetris": "http://3.232.16.65:2626/js/tetris.js"
+        "Tetris": "http://3.232.16.65:8084/js/tetris.js"
     }
 }

--- a/Team-3-BucStop_Tetris/Tetris/appsettings.containers.json
+++ b/Team-3-BucStop_Tetris/Tetris/appsettings.containers.json
@@ -1,0 +1,12 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "MicroserviceUrls": {
+        "Tetris": "http://localhost:8084/js/tetris.js"
+    }
+}

--- a/Team-3-BucStop_Tetris/Tetris/appsettings.containers.json
+++ b/Team-3-BucStop_Tetris/Tetris/appsettings.containers.json
@@ -7,6 +7,6 @@
     },
 
     "MicroserviceUrls": {
-        "Tetris": "http://localhost:8084/js/tetris.js"
+        "Tetris": "http://3.232.16.65:8084/js/tetris.js"
     }
 }

--- a/Team-3-BucStop_Tetris/Tetris/appsettings.containersLocal.json
+++ b/Team-3-BucStop_Tetris/Tetris/appsettings.containersLocal.json
@@ -1,0 +1,12 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+
+    "MicroserviceUrls": {
+        "Tetris": "http://localhost:8084/js/tetris.js"
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,7 @@ services:
     networks:
       - bucstop-network
     environment:
-      - ASPNETCORE_URLS=http://+:80
-      - DOTNET_USE_POLLING_FILE_WATCHER=1
-      - ASPNETCORE_HTTPS_PORT=
+      - DOTNET_ENVIRONMENT=containers
     depends_on:
       - api-gateway
 
@@ -25,6 +23,8 @@ services:
       - "8081:80" # Expose API Gateway on localhost:8081
     networks:
       - bucstop-network
+    environment:
+      - DOTNET_ENVIRONMENT=containers
     depends_on:
       - snake
       - pong
@@ -35,6 +35,8 @@ services:
       context: ./Team-3-BucStop_Snake/Snake
       dockerfile: Dockerfile
     container_name: game-snake
+    environment:
+      - DOTNET_ENVIRONMENT=containers
     ports:
       - "8082:80" # Expose Snake microservice on localhost:8082
     networks:
@@ -45,6 +47,8 @@ services:
       context: ./Team-3-BucStop_Pong/Pong
       dockerfile: Dockerfile
     container_name: game-pong
+    environment:
+      - DOTNET_ENVIRONMENT=containers
     ports:
       - "8083:80" # Expose Pong microservice on localhost:8083
     networks:
@@ -55,6 +59,8 @@ services:
       context: ./Team-3-BucStop_Tetris/Tetris
       dockerfile: Dockerfile
     container_name: game-tetris
+    environment:
+      - DOTNET_ENVIRONMENT=containers
     ports:
       - "8084:80" # Expose Tetris microservice on localhost:8084
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     networks:
       - bucstop-network
     environment:
-      - DOTNET_ENVIRONMENT=containers
+      - DOTNET_ENVIRONMENT=${env}
     depends_on:
       - api-gateway
 
@@ -24,7 +24,7 @@ services:
     networks:
       - bucstop-network
     environment:
-      - DOTNET_ENVIRONMENT=containers
+      - DOTNET_ENVIRONMENT=${env}
     depends_on:
       - snake
       - pong
@@ -36,7 +36,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-snake
     environment:
-      - DOTNET_ENVIRONMENT=containers
+      - DOTNET_ENVIRONMENT=${env}
     ports:
       - "8082:80" # Expose Snake microservice on localhost:8082
     networks:
@@ -48,7 +48,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-pong
     environment:
-      - DOTNET_ENVIRONMENT=containers
+      - DOTNET_ENVIRONMENT=${env}
     ports:
       - "8083:80" # Expose Pong microservice on localhost:8083
     networks:
@@ -60,7 +60,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-tetris
     environment:
-      - DOTNET_ENVIRONMENT=containers
+      - DOTNET_ENVIRONMENT=${env}
     ports:
       - "8084:80" # Expose Tetris microservice on localhost:8084
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     networks:
       - bucstop-network
     environment:
-      - DOTNET_ENVIRONMENT=${env}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     depends_on:
       - api-gateway
 
@@ -24,7 +24,7 @@ services:
     networks:
       - bucstop-network
     environment:
-      - DOTNET_ENVIRONMENT=${env}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     depends_on:
       - snake
       - pong
@@ -36,7 +36,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-snake
     environment:
-      - DOTNET_ENVIRONMENT=${env}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     ports:
       - "8082:80" # Expose Snake microservice on localhost:8082
     networks:
@@ -48,7 +48,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-pong
     environment:
-      - DOTNET_ENVIRONMENT=${env}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     ports:
       - "8083:80" # Expose Pong microservice on localhost:8083
     networks:
@@ -60,7 +60,7 @@ services:
       dockerfile: Dockerfile
     container_name: game-tetris
     environment:
-      - DOTNET_ENVIRONMENT=${env}
+      - DOTNET_ENVIRONMENT=${env:-containersLocal}
     ports:
       - "8084:80" # Expose Tetris microservice on localhost:8084
     networks:


### PR DESCRIPTION
Collaborated with Chris Powers heavily for these code changes

- Added Containerized Appsettings for local runs and EC2 production instance runs
     - appsettings.containers and appsettings.containersLocal
     - `${env}` variable is used in the docker.compose.yaml file to dynamically change the appsettings via `export env=containers`, `env=containersLocal` by default
     
 - Uncontainerized GatewayController urls are also dynamically built based on new IHost environment check
 
- Heartbeat service also uses dynamic url check instead of just localhost, now works on EC2

